### PR TITLE
Packaging for Windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <java.version>17</java.version>
         <javafx.version>17.0.2</javafx.version>
         <packaging>jar</packaging>
+        <mainClass>com.redmondsims.gistfx/com.redmondsims.gistfx.Main</mainClass>
     </properties>
     <dependencies>
         <dependency>
@@ -124,7 +125,7 @@
                     <launcher>gistfx</launcher>
                     <jlinkImageName>gistfx</jlinkImageName>
                     <jlinkZipName>gistfxzip</jlinkZipName>
-                    <mainClass>com.redmondsims.gistfx/com.redmondsims.gistfx.Main</mainClass>
+                    <mainClass>${mainClass}</mainClass>
                 </configuration>
                 <executions>
                     <execution>
@@ -138,7 +139,7 @@
                             <launcher>gistfx</launcher>
                             <jlinkImageName>gistfx</jlinkImageName>
                             <jlinkZipName>gistfxzip</jlinkZipName>
-                            <mainClass>com.redmondsims.gistfx/com.redmondsims.gistfx.Main</mainClass>
+                            <mainClass>${mainClass}</mainClass>
                         </configuration>
                     </execution>
                 </executions>
@@ -152,11 +153,63 @@
                         <manifestEntries>
                             <Main-Class>com.redmondsims.gistfx.Main</Main-Class>
                             <Automatic-Module-Name>com.redmondsims.gistfx</Automatic-Module-Name>
-                            <Program-Version>${version}</Program-Version>
-                            <Implementation-Version>${version}</Implementation-Version>
+                            <Program-Version>${project.version}</Program-Version>
+                            <Implementation-Version>${project.version}</Implementation-Version>
                         </manifestEntries>
                     </archive>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.github.fvarrui</groupId>
+                <artifactId>javapackager</artifactId>
+                <version>1.6.5</version>
+                <configuration>
+                    <mainClass>${mainClass}</mainClass>
+                    <bundleJre>true</bundleJre>
+                    <customizedJre>false</customizedJre>
+                    <generateInstaller>true</generateInstaller>
+                    <administratorRequired>false</administratorRequired>
+                    <createZipball>false</createZipball>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>package-for-windows</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <platform>windows</platform>
+                            <createTarball>false</createTarball>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>package-for-linux</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <platform>linux</platform>
+                            <createTarball>true</createTarball>
+                            <!-- to bundle a jre for linux when packaging from windows  -->
+                            <!-- <jdkPath>path/to/linux/jdk</jdkPath> -->
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>package-for-mac</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <platform>mac</platform>
+                            <createTarball>true</createTarball>
+                            <!-- to bundle a jre for mac when packaging from windows  -->
+                            <!-- <jdkPath>path/to/mac/jdk</jdkPath> -->
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <java.version>17</java.version>
         <javafx.version>17.0.2</javafx.version>
         <packaging>jar</packaging>
-        <mainClass>com.redmondsims.gistfx/com.redmondsims.gistfx.Main</mainClass>
+        <exec.mainClass>com.redmondsims.gistfx.Main</exec.mainClass>
     </properties>
     <dependencies>
         <dependency>
@@ -125,7 +125,7 @@
                     <launcher>gistfx</launcher>
                     <jlinkImageName>gistfx</jlinkImageName>
                     <jlinkZipName>gistfxzip</jlinkZipName>
-                    <mainClass>${mainClass}</mainClass>
+                    <mainClass>com.redmondsims.gistfx/${exec.mainClass}</mainClass>
                 </configuration>
                 <executions>
                     <execution>
@@ -139,7 +139,7 @@
                             <launcher>gistfx</launcher>
                             <jlinkImageName>gistfx</jlinkImageName>
                             <jlinkZipName>gistfxzip</jlinkZipName>
-                            <mainClass>${mainClass}</mainClass>
+                            <mainClass>com.redmondsims.gistfx/${exec.mainClass}</mainClass>
                         </configuration>
                     </execution>
                 </executions>
@@ -151,7 +151,7 @@
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Main-Class>com.redmondsims.gistfx.Main</Main-Class>
+                            <Main-Class>${exec.mainClass}</Main-Class>
                             <Automatic-Module-Name>com.redmondsims.gistfx</Automatic-Module-Name>
                             <Program-Version>${project.version}</Program-Version>
                             <Implementation-Version>${project.version}</Implementation-Version>
@@ -164,12 +164,11 @@
                 <artifactId>javapackager</artifactId>
                 <version>1.6.5</version>
                 <configuration>
-                    <mainClass>${mainClass}</mainClass>
+                    <mainClass>${exec.mainClass}</mainClass>
                     <bundleJre>true</bundleJre>
                     <customizedJre>false</customizedJre>
                     <generateInstaller>true</generateInstaller>
                     <administratorRequired>false</administratorRequired>
-                    <createZipball>false</createZipball>
                 </configuration>
                 <executions>
                     <execution>
@@ -180,33 +179,15 @@
                         </goals>
                         <configuration>
                             <platform>windows</platform>
-                            <createTarball>false</createTarball>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>package-for-linux</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>package</goal>
-                        </goals>
-                        <configuration>
-                            <platform>linux</platform>
-                            <createTarball>true</createTarball>
-                            <!-- to bundle a jre for linux when packaging from windows  -->
-                            <!-- <jdkPath>path/to/linux/jdk</jdkPath> -->
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>package-for-mac</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>package</goal>
-                        </goals>
-                        <configuration>
-                            <platform>mac</platform>
-                            <createTarball>true</createTarball>
-                            <!-- to bundle a jre for mac when packaging from windows  -->
-                            <!-- <jdkPath>path/to/mac/jdk</jdkPath> -->
+                            <createZipball>false</createZipball>
+                            <vmArgs>
+                                <vmArg>--module-path=libs</vmArg>
+                                <vmArg>--add-modules=javafx.controls,javafx.graphics</vmArg>
+                            </vmArgs>
+                            <winConfig>
+                                <headerType>console</headerType>
+                                <generateMsi>false</generateMsi>
+                            </winConfig>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/main/java/com/redmondsims/gistfx/Main.java
+++ b/src/main/java/com/redmondsims/gistfx/Main.java
@@ -26,7 +26,7 @@ import static com.redmondsims.gistfx.enums.OS.MAC;
 public class Main extends Application {
 
     public static final  String APP_TITLE    = "GistFX";
-    private static final String dockIconBase = "Artwork/%s/Icons/AppleDock.png";
+    private static final String dockIconBase = "ArtWork/%s/Icons/AppleDock.png";
     private static final JFrame jFrame       = new JFrame();
 
     private static void setAnchors(Node node, double left, double right, double top, double bottom) {


### PR DESCRIPTION
Hi @EasyG0ing1!
I've added JavaPackager to your project, in order to generate a native version for Windows. Now it's being packaged without problems, but there are several errors accessing resources which are located inside a JAR file (EXE file in this case, but is the same).

```
C:\Users\fvarrui\GitHub\GistFX\target\gistfx>gistfx.exe
ArtWork/Green/Icons/AppleDock.png
jar:file:/C:/Users/fvarrui/GitHub/GistFX/target/gistfx/gistfx.exe!/com/redmondsims/gistfx/ArtWork/Green/Icons/AppleDock.png
java.sql.SQLException: path to 'C:\Users\fvarrui\GitHub\GistFX\target\gistfx\jar:\C:\Users\fvarrui\GitHub\GistFX\target\gistfx\gistfx.exe!\com\redmondsims\gistfx\SQLite\Database.sqlite': 'C:\Users\fvarrui\GitHub\GistFX\target\gistfx\jar:' does not exist
        at org.xerial.sqlitejdbc@3.36.0.3/org.sqlite.SQLiteConnection.open(SQLiteConnection.java:220)
        at org.xerial.sqlitejdbc@3.36.0.3/org.sqlite.SQLiteConnection.<init>(SQLiteConnection.java:61)
        at org.xerial.sqlitejdbc@3.36.0.3/org.sqlite.jdbc3.JDBC3Connection.<init>(JDBC3Connection.java:28)
        at org.xerial.sqlitejdbc@3.36.0.3/org.sqlite.jdbc4.JDBC4Connection.<init>(JDBC4Connection.java:21)
        at org.xerial.sqlitejdbc@3.36.0.3/org.sqlite.JDBC.createConnection(JDBC.java:115)
        at org.xerial.sqlitejdbc@3.36.0.3/org.sqlite.JDBC.connect(JDBC.java:90)
        at java.sql/java.sql.DriverManager.getConnection(DriverManager.java:681)
        at java.sql/java.sql.DriverManager.getConnection(DriverManager.java:252)
        at com.redmondsims.gistfx.data.SQLite.setConnection(SQLite.java:45)
        at com.redmondsims.gistfx.data.Action.setDatabaseConnection(Action.java:42)
        at com.redmondsims.gistfx.Main.start(Main.java:155)
        at javafx.graphics/com.sun.javafx.application.LauncherImpl.lambda$launchApplication1$9(LauncherImpl.java:847)
        at javafx.graphics/com.sun.javafx.application.PlatformImpl.lambda$runAndWait$12(PlatformImpl.java:484)
        at javafx.graphics/com.sun.javafx.application.PlatformImpl.lambda$runLater$10(PlatformImpl.java:457)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
        at javafx.graphics/com.sun.javafx.application.PlatformImpl.lambda$runLater$11(PlatformImpl.java:456)
        at javafx.graphics/com.sun.glass.ui.InvokeLaterDispatcher$Future.run(InvokeLaterDispatcher.java:96)
        at javafx.graphics/com.sun.glass.ui.win.WinApplication._runLoop(Native Method)
        at javafx.graphics/com.sun.glass.ui.win.WinApplication.lambda$runLoop$3(WinApplication.java:184)
        at java.base/java.lang.Thread.run(Thread.java:833)


SQLite.setDatabaseConnection(): path to 'C:\Users\fvarrui\GitHub\GistFX\target\gistfx\jar:\C:\Users\fvarrui\GitHub\GistFX\target\gistfx\gistfx.exe!\com\redmondsims\gistfx\SQLite\Database.sqlite': 'C:\Users\fvarrui\GitHub\GistFX\target\gistfx\jar:' does not exist




The SQLite library failed to create the database file.
        Make sure your Access Control Lists are permissive for the folder that GistFX executes from.

Run program from a command prompt to see the full stack trace.

Exiting...
Exception in Application start method
java.lang.reflect.InvocationTargetException
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at javafx.graphics/com.sun.javafx.application.LauncherImpl.launchApplicationWithArgs(LauncherImpl.java:465)
        at javafx.graphics/com.sun.javafx.application.LauncherImpl.launchApplication(LauncherImpl.java:364)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at java.base/sun.launcher.LauncherHelper$FXHelper.main(LauncherHelper.java:1071)
Caused by: java.lang.RuntimeException: Exception in Application start method
        at javafx.graphics/com.sun.javafx.application.LauncherImpl.launchApplication1(LauncherImpl.java:901)
        at javafx.graphics/com.sun.javafx.application.LauncherImpl.lambda$launchApplication$2(LauncherImpl.java:196)
        at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.nio.file.InvalidPathException: Illegal char <:> at index 3: jar:\C:\Users\fvarrui\GitHub\GistFX\target\gistfx\gistfx.exe!\com\redmondsims\gistfx\SQLite\GistFXCreateSchema.sql
        at java.base/sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:182)
        at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:153)
        at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:77)
        at java.base/sun.nio.fs.WindowsPath.parse(WindowsPath.java:92)
        at java.base/sun.nio.fs.WindowsFileSystem.getPath(WindowsFileSystem.java:232)
        at java.base/java.io.File.toPath(File.java:2387)
        at com.redmondsims.gistfx.data.Disk.loadTextFile(Disk.java:17)
        at com.redmondsims.gistfx.data.Action.loadTextFile(Action.java:318)
        at com.redmondsims.gistfx.data.SQLite.setConnection(SQLite.java:60)
        at com.redmondsims.gistfx.data.Action.setDatabaseConnection(Action.java:42)
        at com.redmondsims.gistfx.Main.start(Main.java:155)
        at javafx.graphics/com.sun.javafx.application.LauncherImpl.lambda$launchApplication1$9(LauncherImpl.java:847)
        at javafx.graphics/com.sun.javafx.application.PlatformImpl.lambda$runAndWait$12(PlatformImpl.java:484)
        at javafx.graphics/com.sun.javafx.application.PlatformImpl.lambda$runLater$10(PlatformImpl.java:457)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
        at javafx.graphics/com.sun.javafx.application.PlatformImpl.lambda$runLater$11(PlatformImpl.java:456)
        at javafx.graphics/com.sun.glass.ui.InvokeLaterDispatcher$Future.run(InvokeLaterDispatcher.java:96)
        at javafx.graphics/com.sun.glass.ui.win.WinApplication._runLoop(Native Method)
        at javafx.graphics/com.sun.glass.ui.win.WinApplication.lambda$runLoop$3(WinApplication.java:184)
        ... 1 more
Exception in thread "JavaFX Application Thread" java.lang.IllegalStateException: This operation is permitted on the event thread only; currentThread = JavaFX Application Thread
        at javafx.graphics/com.sun.glass.ui.Application.checkEventThread(Application.java:447)
        at javafx.graphics/com.sun.glass.ui.Application.isNestedLoopRunning(Application.java:548)
        at javafx.graphics/com.sun.javafx.tk.quantum.QuantumToolkit.isNestedLoopRunning(QuantumToolkit.java:1214)
        at javafx.graphics/com.sun.javafx.tk.quantum.QuantumToolkit.enterNestedEventLoop(QuantumToolkit.java:649)
        at javafx.graphics/javafx.stage.Stage.showAndWait(Stage.java:465)
        at javafx.controls/javafx.scene.control.HeavyweightDialog.showAndWait(HeavyweightDialog.java:162)
        at javafx.controls/javafx.scene.control.Dialog.showAndWait(Dialog.java:346)
        at com.redmondsims.gistfx.alerts.CustomAlert.showWarning(CustomAlert.java:113)
        at com.redmondsims.gistfx.alerts.CustomAlert.showWarning(CustomAlert.java:117)
        at com.redmondsims.gistfx.data.SQLite.lambda$setConnection$0(SQLite.java:55)
        at javafx.graphics/com.sun.javafx.application.PlatformImpl.lambda$runLater$10(PlatformImpl.java:457)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
        at javafx.graphics/com.sun.javafx.application.PlatformImpl.lambda$runLater$11(PlatformImpl.java:456)
        at javafx.graphics/com.sun.glass.ui.InvokeLaterDispatcher$Future.run(InvokeLaterDispatcher.java:96)
        at javafx.graphics/com.sun.glass.ui.win.WinApplication._runLoop(Native Method)
        at javafx.graphics/com.sun.glass.ui.win.WinApplication.lambda$runLoop$3(WinApplication.java:184)
        at java.base/java.lang.Thread.run(Thread.java:833)
Exception running application com.redmondsims.gistfx.Main
```

I haven't had time to investigate further, but it seems that your app is trying to access to a SQLite database that doesn't exist... and possibly can't be created because you're trying to access/modify the contents of the JAR/EXE . If so, you have to use another location to create dynamic resources. I hope I've explained myself!
